### PR TITLE
fix: validate Kahoot quiz IDs and prevent GUI title crash

### DIFF
--- a/Kitty/client.py
+++ b/Kitty/client.py
@@ -49,6 +49,16 @@ from colorama import Fore, Style
 from pystyle import Write, System, Colors, Colorate, Anime
 from datetime import datetime
 
+UUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+def extract_uuid(value):
+    """Return a Kahoot UUID from raw input or a shared Kahoot URL."""
+    value = (value or "").strip()
+    match = UUID_PATTERN.search(value)
+    return match.group(0) if match else value
+
 # Colors :D
 red = Fore.RED
 yellow = Fore.YELLOW
@@ -117,15 +127,16 @@ api = "https://play.kahoot.it/rest/kahoots/"
 
 class Kahoot:
     def __init__(self, uuid):
-        self.uuid = uuid
+        self.uuid = extract_uuid(uuid)
         self.rate_limiter = RateLimiter()
         self.ssl_context = SSLContextManager.create_ssl_context()
         
         try:
-            if not re.fullmatch(r"^[A-Za-z0-9-]*$", uuid):
+            if not UUID_PATTERN.fullmatch(self.uuid):
+                print("Error: Invalid Quiz ID format. Paste a Kahoot share/details URL or UUID, not a live game PIN.")
                 self.data = False
             else:
-                self.data = self._fetch_quiz_data(uuid)
+                self.data = self._fetch_quiz_data(self.uuid)
         except HTTPError or InvalidURL:
             self.data = False
 
@@ -165,6 +176,12 @@ class Kahoot:
                     return load(response)
                     
             except HTTPError as e:
+                body = ""
+                try:
+                    body = e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    pass
+
                 if e.code == 403:
                     print(f"Attempt {attempt + 1}: Access forbidden (403)")
                     if attempt < max_retries - 1:
@@ -178,6 +195,17 @@ class Kahoot:
                 
                 elif e.code == 404:
                     print("Error: Quiz not found. Please verify the Quiz ID is correct.")
+                    return False
+
+                elif e.code == 400:
+                    detail = "Bad request. Kahoot rejected the ID format."
+                    try:
+                        payload = json.loads(body)
+                        detail = payload.get("fields", {}).get("arg1") or payload.get("error") or detail
+                    except Exception:
+                        pass
+                    print(f"HTTP Error 400: {detail}")
+                    print("Tip: use the UUID from a Kahoot share/details URL. A live game PIN is not a Quiz ID.")
                     return False
                 
                 elif e.code == 429:  # Too Many Requests

--- a/LITE/lite.py
+++ b/LITE/lite.py
@@ -2,9 +2,20 @@
 
 import json
 import urllib.request
+import urllib.error
 import os
+import re
 from os import system
 import platform
+
+UUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+def extract_uuid(value):
+    value = (value or "").strip()
+    match = UUID_PATTERN.search(value)
+    return match.group(0) if match else value
 
 print(f"'{system}'") # OS Alert
 
@@ -19,7 +30,8 @@ print("""
 """)
 api = 'https://play.kahoot.it/rest/kahoots/'
 usrinput = input(f" Enter ID >> ")
-link = api + usrinput
+quiz_id = extract_uuid(usrinput)
+link = api + quiz_id
 finished = False
 
 answers = {}
@@ -27,6 +39,9 @@ images = {}
 questions = {}
 
 try:
+    if not UUID_PATTERN.fullmatch(quiz_id):
+        raise ValueError("Invalid Quiz ID format. Paste a Kahoot share/details URL or UUID, not a live game PIN.")
+
     with urllib.request.urlopen(link) as url:
         print("")
         data = json.load(url)
@@ -103,6 +118,15 @@ try:
 
                 question += 1
 
+except urllib.error.HTTPError as err:
+    os.system('clear')
+    print("Womp Womp! ")
+    print("There was an error!  Mabey you typed the 'Quiz ID' incorrectly!\n")
+    try:
+        body = err.read().decode("utf-8", errors="replace")
+        print(f"HTTP {err.code}: {body}")
+    except Exception:
+        print(err)
 except Exception as err:
     os.system('clear')
     print("Womp Womp! ")
@@ -123,7 +147,7 @@ print_answers()
 if finished:
     # try:
     dir_path = os.path.dirname(os.path.realpath(__file__))
-    data_path = os.path.join(dir_path, "quizzes", f"{usrinput}.json")
+    data_path = os.path.join(dir_path, "quizzes", f"{quiz_id}.json")
 
     if not os.path.exists(os.path.join(dir_path, "quizzes")):
         os.mkdir(os.path.join(dir_path, "quizzes"), 0o666)

--- a/src/client.py
+++ b/src/client.py
@@ -43,6 +43,16 @@ check_and_install_dependencies()
 from colorama import Fore, Style
 from pystyle import Write, System, Colors, Colorate, Anime
 
+UUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+def extract_uuid(value):
+    """Return a Kahoot UUID from raw input or a shared Kahoot URL."""
+    value = (value or "").strip()
+    match = UUID_PATTERN.search(value)
+    return match.group(0) if match else value
+
 class ColorScheme:
     RED = Fore.RED
     YELLOW = Fore.YELLOW
@@ -191,6 +201,12 @@ class KahootAPI:
                     return json.loads(response.read().decode('utf-8'))
                     
             except HTTPError as e:
+                body = ""
+                try:
+                    body = e.read().decode("utf-8", errors="replace")
+                except Exception:
+                    pass
+
                 if e.code == 403:
                     print(f"Attempt {attempt + 1}: Access forbidden (403)")
                     if attempt < max_retries - 1:
@@ -203,6 +219,15 @@ class KahootAPI:
                 
                 elif e.code == 404:
                     return {'error': 'Quiz not found. The ID may be incorrect.'}
+
+                elif e.code == 400:
+                    detail = "Bad request. Kahoot rejected the ID or PIN format."
+                    try:
+                        payload = json.loads(body)
+                        detail = payload.get("fields", {}).get("arg1") or payload.get("error") or detail
+                    except Exception:
+                        pass
+                    return {'error': f'HTTP 400: {detail}'}
                 
                 elif e.code == 429:  # Too Many Requests
                     if attempt < max_retries - 1:
@@ -244,8 +269,16 @@ class KahootAPI:
     
     @staticmethod
     def get_quiz_by_id(quiz_id):
-        if not re.fullmatch(r"^[A-Za-z0-9-]*$", quiz_id):
-            return {'error': 'Invalid quiz ID format'}
+        quiz_id = extract_uuid(quiz_id)
+
+        if not UUID_PATTERN.fullmatch(quiz_id):
+            return {
+                'error': (
+                    'Invalid Quiz ID format. Use the UUID from a Kahoot share/details URL, '
+                    'for example 465ccb62-0679-4011-9f99-7471f217f4e9. '
+                    'A live game PIN is not the same as a Quiz ID.'
+                )
+            }
         
         api = KahootAPI()
         url = f"{api.BASE_API_URL}{quiz_id}"
@@ -264,8 +297,14 @@ class KahootAPI:
             return {'quiz_id': result['id']}
         elif 'error' not in result:
             return {'error': 'No quiz ID found in response'}
-        
-        return result
+
+        return {
+            'error': (
+                f"{result['error']} This lookup only works for Kahoot challenge/assignment PINs. "
+                "Live game PINs usually cannot be converted to a Quiz ID by this endpoint; "
+                "use the quiz share/details URL or UUID instead."
+            )
+        }
 
 class KahootQuiz:    
     def __init__(self, quiz_data):
@@ -475,10 +514,11 @@ class KahootClientUI:
                     time.sleep(1)
                     return quiz_id
             else:
-                if re.fullmatch(r"^[A-Za-z0-9-]*$", user_input):
-                    return user_input
+                quiz_id = extract_uuid(user_input)
+                if UUID_PATTERN.fullmatch(quiz_id):
+                    return quiz_id
                 else:
-                    print(f"{ColorScheme.RED}Invalid quiz ID format. It should contain only letters, numbers, and hyphens.")
+                    print(f"{ColorScheme.RED}Invalid quiz ID format. Paste a Kahoot share/details URL or a UUID, not a live game PIN.")
                     retry = input(f"{ColorScheme.YELLOW}Try again? (y/n): {ColorScheme.RESET}").lower()
                     if retry != 'y':
                         return None
@@ -499,25 +539,42 @@ class KahootClientUI:
         print(f"{ColorScheme.CYAN}====================================\n")
         
         output_lock = threading.Lock()
+        displayed_blocks = 0
         
         for i in range(kahoot.get_quiz_length()):
-            question_details = kahoot.get_question_details(i)
-            
-            with output_lock:
-                if question_details["type"] == "content":
-                    print(f"{ColorScheme.YELLOW}SLIDE {i+1}: {question_details['title']}")
-                    if question_details.get('description'):
-                        print(f"{ColorScheme.GRAY}Description: {question_details['description']}{ColorScheme.RESET}\n")
-                else:
-                    print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Question {i+1}{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}{question_details['question']}{ColorScheme.ORANGE}]{ColorScheme.RESET}")
-                    
-                    answers = kahoot.get_answer(i)
-                    if answers:
-                        print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Answer{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}{', '.join(answers)}{ColorScheme.ORANGE}]{ColorScheme.RESET}\n")
+            try:
+                question_details = kahoot.get_question_details(i)
+
+                if not question_details:
+                    with output_lock:
+                        print(f"{ColorScheme.YELLOW}BLOCK {i+1}: Could not read this question block.{ColorScheme.RESET}\n")
+                    displayed_blocks += 1
+                    continue
+                
+                with output_lock:
+                    if question_details["type"] == "content":
+                        print(f"{ColorScheme.YELLOW}SLIDE {i+1}: {question_details['title']}")
+                        if question_details.get('description'):
+                            print(f"{ColorScheme.GRAY}Description: {question_details['description']}{ColorScheme.RESET}")
+                        print("")
                     else:
-                        print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Answer{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}No correct answers found{ColorScheme.ORANGE}]{ColorScheme.RESET}\n")
+                        print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Question {i+1}{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}{question_details['question']}{ColorScheme.ORANGE}]{ColorScheme.RESET}")
+                        
+                        answers = kahoot.get_answer(i)
+                        if answers:
+                            print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Answer{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}{', '.join(answers)}{ColorScheme.ORANGE}]{ColorScheme.RESET}\n")
+                        else:
+                            print(f"{ColorScheme.PRETTY}{ColorScheme.ORANGE}[{ColorScheme.RESET}Answer{ColorScheme.ORANGE}]{ColorScheme.GREEN}--{ColorScheme.ORANGE}[{ColorScheme.RESET}No correct answers found{ColorScheme.ORANGE}]{ColorScheme.RESET}\n")
+
+                displayed_blocks += 1
+            except Exception as err:
+                with output_lock:
+                    print(f"{ColorScheme.RED}BLOCK {i+1}: Failed to process this question: {err}{ColorScheme.RESET}\n")
+                displayed_blocks += 1
             
             time.sleep(0.010)
+
+        print(f"{ColorScheme.CYAN}Displayed {displayed_blocks} of {kahoot.get_quiz_length()} blocks returned by Kahoot.{ColorScheme.RESET}")
     
     @staticmethod
     def display_options(kahoot):

--- a/src/client/main.py
+++ b/src/client/main.py
@@ -12,6 +12,7 @@ import urllib.error
 from urllib.parse import urlparse
 from datetime import datetime
 from functools import partial
+import re
 
 from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QHBoxLayout, 
                              QPushButton, QLabel, QLineEdit, QTabWidget, QTextEdit, 
@@ -20,6 +21,15 @@ from PyQt5.QtWidgets import (QApplication, QMainWindow, QWidget, QVBoxLayout, QH
                              QHeaderView, QComboBox, QFileDialog, QCheckBox, QGroupBox, QStackedWidget)
 from PyQt5.QtCore import (Qt, QThread, pyqtSignal, QSize, QTimer, QRect)
 from PyQt5.QtGui import (QFont, QColor, QPalette, QIcon, QPainter)
+
+UUID_PATTERN = re.compile(
+    r"[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}"
+)
+
+def extract_uuid(value):
+    value = (value or "").strip()
+    match = UUID_PATTERN.search(value)
+    return match.group(0) if match else value
 
 class ThemeEngine:
     class Colors:
@@ -322,6 +332,15 @@ class KahootAPI:
     @staticmethod
     def get_quiz_by_id(quiz_id):
         try:
+            quiz_id = extract_uuid(quiz_id)
+            if not UUID_PATTERN.fullmatch(quiz_id):
+                return {
+                    "error": (
+                        "Invalid Quiz ID format. Paste a Kahoot share/details URL or UUID. "
+                        "A live game PIN is not the same as a Quiz ID."
+                    )
+                }
+
             url = f"{KahootAPI.BASE_API}{quiz_id}"
             headers = {
                 'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
@@ -330,6 +349,23 @@ class KahootAPI:
             request = urllib.request.Request(url, headers=headers)
             with urllib.request.urlopen(request, timeout=10) as response:
                 return json.loads(response.read().decode('utf-8'))
+        except urllib.error.HTTPError as e:
+            body = ""
+            try:
+                body = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+
+            if e.code == 400:
+                detail = "Bad request. Kahoot rejected the ID or PIN format."
+                try:
+                    payload = json.loads(body)
+                    detail = payload.get("fields", {}).get("arg1") or payload.get("error") or detail
+                except Exception:
+                    pass
+                return {"error": f"HTTP 400: {detail}"}
+
+            return {"error": f"HTTP Error {e.code}: {e.reason}"}
         except Exception as e:
             return {"error": str(e)}
     
@@ -345,6 +381,26 @@ class KahootAPI:
             with urllib.request.urlopen(request, timeout=10) as response:
                 data = json.loads(response.read().decode('utf-8'))
                 return {'quiz_id': data.get('id')}
+        except urllib.error.HTTPError as e:
+            body = ""
+            try:
+                body = e.read().decode("utf-8", errors="replace")
+            except Exception:
+                pass
+
+            detail = f"HTTP Error {e.code}: {e.reason}"
+            if e.code == 400:
+                try:
+                    payload = json.loads(body)
+                    detail = payload.get("fields", {}).get("arg1") or payload.get("error") or detail
+                except Exception:
+                    pass
+                detail = (
+                    f"HTTP 400: {detail}. This lookup only works for challenge/assignment PINs; "
+                    "live game PINs usually cannot be converted to a Quiz ID by this endpoint."
+                )
+
+            return {"error": detail}
         except Exception as e:
             return {"error": str(e)}
 
@@ -824,20 +880,20 @@ class AnswerViewerTab(QWidget):
         self.loading_overlay.hide()
         self.current_kahoot = kahoot
         
-        details = kahoot.get_quiz_details()
+        quiz_details = kahoot.get_quiz_details()
         
         self.quiz_info.clear()
         
         html_content = f"""
         <div style="font-family: '{ThemeEngine.Fonts.FAMILY_MAIN}', {ThemeEngine.Fonts.FAMILY_FALLBACK};">
-            <h2 style="color: {ThemeEngine.Colors.PUMPKIN}; margin-bottom: 10px;">{details['title']}</h2>
-            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Creator:</b> {details['creator_username']}</p>
-            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Quiz ID:</b> {details['uuid']}</p>
-            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Questions:</b> {details['question_count']}</p>
+            <h2 style="color: {ThemeEngine.Colors.PUMPKIN}; margin-bottom: 10px;">{quiz_details['title']}</h2>
+            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Creator:</b> {quiz_details['creator_username']}</p>
+            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Quiz ID:</b> {quiz_details['uuid']}</p>
+            <p><b style="color: {ThemeEngine.Colors.PUMPKIN};">Questions:</b> {quiz_details['question_count']}</p>
         """
         
-        if details['description']:
-            html_content += f"<p><b style='color: {ThemeEngine.Colors.PUMPKIN};'>Description:</b> {details['description']}</p>"
+        if quiz_details['description']:
+            html_content += f"<p><b style='color: {ThemeEngine.Colors.PUMPKIN};'>Description:</b> {quiz_details['description']}</p>"
         
         html_content += "</div>"
         
@@ -846,9 +902,9 @@ class AnswerViewerTab(QWidget):
         self.table.setRowCount(0)
         
         for i in range(kahoot.get_quiz_length()):
-            details = kahoot.get_question_details(i)
+            question_details = kahoot.get_question_details(i)
             
-            if details["type"] == "content":
+            if question_details["type"] == "content":
                 continue
             
             row = self.table.rowCount()
@@ -858,7 +914,7 @@ class AnswerViewerTab(QWidget):
             number_item.setTextAlignment(Qt.AlignCenter)
             self.table.setItem(row, 0, number_item)
             
-            question_item = QTableWidgetItem(details["question"])
+            question_item = QTableWidgetItem(question_details["question"])
             self.table.setItem(row, 1, question_item)
             
             answers = kahoot.get_answer(i)
@@ -882,7 +938,7 @@ class AnswerViewerTab(QWidget):
         QMessageBox.information(
             self,
             "Quiz Loaded",
-            f"Successfully loaded quiz: {details['title']}",
+            f"Successfully loaded quiz: {quiz_details['title']}",
             QMessageBox.Ok
         )
     


### PR DESCRIPTION
- Validate Kahoot quiz UUIDs before calling the API
- Extract UUIDs automatically from Kahoot share/details URLs
- Improve HTTP 400 error messages for invalid IDs or PINs
- Fix GUI crash after loading a quiz caused by overwritten quiz details
- Make terminal answer display continue even if one question block fails